### PR TITLE
get_courses_content()

### DIFF
--- a/src/pronote.js
+++ b/src/pronote.js
@@ -589,13 +589,9 @@ class User {
 							title: f.L,
 							description: util.decodeHTML(f.descriptif.V),
 							rawDescription: f.descriptif.V,
-							files: f.ListePieceJointe.V.map(ff => (function (ff) {
-								if (ff !== undefined) {
-									return {
-										name: ff.L,
-										url: file(pointer_this.details.url, ff.L, {N: ff.N, G: 48})
-									}
-								}
+							files: f.ListePieceJointe.V..filter(ff => ff).map(ff => ({
+								name: ff.L,
+								url: file(pointer_this.details.url, session, ff.L, {N: ff.N, G: 48})
 							}))
 						}))
 					})


### PR DESCRIPTION
- Les pièces jointes renvoient un objet, et non plus une fonction inutile
- Usage d'un filter pour retirer les éléments undefined
- Correction de l'usage de file() dans lequel il manquait l'argument de la session